### PR TITLE
 feat/plugin-options

### DIFF
--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -1,3 +1,8 @@
 module.exports = {
-  plugins: ["@raae/gatsby-plugin-donations"],
+  plugins: [
+    {
+      resolve: "@raae/gatsby-plugin-donations",
+      options: { api_key: "123" },
+    },
+  ],
 };

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -1,5 +1,10 @@
 // https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/
 
+exports.onPreInit = (_, options) => {
+  const { api_key } = options;
+  process.env.api_key = api_key;
+};
+
 exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     option1: Joi.string()

--- a/plugin/src/api/@raae/gatsby-plugin-donations/donation.js
+++ b/plugin/src/api/@raae/gatsby-plugin-donations/donation.js
@@ -13,6 +13,9 @@ const stripe = Stripe();
 export default async (req, res) => {
   console.log(`${req.baseUrl} - ${req.method}`);
 
+  // The api_key is available on process.env because it's set in gatsby-node => onPreInit
+  console.log("process.env.api_key: ", process.env.api_key);
+
   try {
     if (req.method === "POST") {
       await createStripeSession(req, res);


### PR DESCRIPTION
Hi friend, not entirely sure i understood your `env` conundrum but if i've understood correctly you wanted "users" to be able to pass api keys through plugin options as they normally would for all other types of Gatsby plugins, but the problem was these weren't then picked up by Serverless Functions in `src/api`

To circumvent the Gatsby build step which i don't think adds plugin options to the environment i've used the `onPreInit` extension point to grab the `api_key` value from the plugin options, set it on the environment which then makes it available for use later in the Serverless Function. 

I've tested this with `gatsby develop`, perhaps i can add a `build` to the root `package.json` and test this with a `gatsby build` and `gatsby-serve` I'd like to see if there's a difference between the `dev` and `prod` env vars


Anyway, if this is what you were kind of looking for i'm happy to give it another go. 


**TODO**

- Add `api_key` to plugin schema
- Determin name for `api_key` => `apiKey` || `stripeApiSecret` etc


